### PR TITLE
Potential fix for code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/pages/api/summarizePdf.js
+++ b/pages/api/summarizePdf.js
@@ -61,6 +61,17 @@ export default async function handler( req, res ) {
             return res.status( 400 ).json( { error: "Missing PDF URL or Issue Number" } );
         }
 
+        // Validate the PDF URL
+        const allowedDomains = [ "trustedsource.com", "anothertrustedsource.org" ];
+        try {
+            const parsedUrl = new URL( pdfUrl );
+            if ( !allowedDomains.includes( parsedUrl.hostname ) ) {
+                return res.status( 400 ).json( { error: "Invalid PDF URL domain" } );
+            }
+        } catch ( error ) {
+            return res.status( 400 ).json( { error: "Invalid PDF URL format" } );
+        }
+
         const db = await connectToDatabase();
         const collection = db.collection( COLLECTION_NAME );
         const chunkCollection = db.collection( CHUNK_COLLECTION );


### PR DESCRIPTION
Potential fix for [https://github.com/gottasellemall69/congressional-reports-summaries/security/code-scanning/1](https://github.com/gottasellemall69/congressional-reports-summaries/security/code-scanning/1)

To fix the SSRF vulnerability, we need to validate the `pdfUrl` parameter to ensure it points to a safe and expected domain. The best approach is to use an allow-list of trusted domains and verify that the user-provided URL belongs to one of these domains. This ensures that only URLs from known, safe sources are allowed.

Steps to implement the fix:
1. Parse the `pdfUrl` using the `URL` constructor to extract its hostname.
2. Compare the hostname against an allow-list of trusted domains.
3. Reject the request with an appropriate error message if the hostname is not in the allow-list.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
