### PR TITLE
Potential fix for code scanning alert no. 6: Database query built from user-controlled sources

### DIFF
--- a/pages/api/summarizePdf.js
+++ b/pages/api/summarizePdf.js
@@ -61,6 +61,11 @@ export default async function handler( req, res ) {
             return res.status( 400 ).json( { error: "Missing PDF URL or Issue Number" } );
         }
 
+        // Validate issueNumber
+        if ( typeof issueNumber !== "string" && typeof issueNumber !== "number" ) {
+            return res.status( 400 ).json( { error: "Invalid Issue Number format" } );
+        }
+
         // Validate the PDF URL
         const allowedDomains = [ "trustedsource.com", "anothertrustedsource.org" ];
         try {


### PR DESCRIPTION
Potential fix for [https://github.com/gottasellemall69/congressional-reports-summaries/security/code-scanning/6](https://github.com/gottasellemall69/congressional-reports-summaries/security/code-scanning/6)

To fix the issue, we need to ensure that the `issueNumber` value is sanitized or validated before being used in the MongoDB query. The best approach is to validate that `issueNumber` is a literal value (e.g., a string or number) and not a complex object that could include malicious query operators. This can be achieved by adding a type check for `issueNumber` and rejecting the request if it does not meet the expected criteria.

Specifically:
1. Add a check to ensure that `issueNumber` is a string or number.
2. If the validation fails, return a `400 Bad Request` response with an appropriate error message.
3. Proceed with the query only if the validation passes.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
